### PR TITLE
Publish el7_8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The following list shows the expected tag to (example) transformation for RPM's
 
 |Tag|Tree State|Output RPM|RPM Channel|Notes|
 |:--|:---------|:---------|:----------|:----|
-| master (no tag) | Clean | `rke2-selinux-0.0~0d52f7d8-0.el7.noarch.rpm` | Testing ||
-| master (no tag) | Dirty | `rke2-selinux-0.0~0d52f7d8-0.el7.noarch.rpm` | Testing ||
-| v0.2.testing.1 | Clean | `rke2-selinux-0.2-1.el7.noarch.rpm` | Testing ||
-| v0.2.latest.1 | Clean | `rke2-selinux-0.2-1.el7.noarch.rpm` | Latest ||
-| v0.2.latest.2 | Clean | `rke2-selinux-0.2-2.el7.noarch.rpm` | Latest ||
+| master (no tag) | Clean | `rke2-selinux-0.0~0d52f7d8-0.el7_8.noarch.rpm` | Testing ||
+| master (no tag) | Dirty | `rke2-selinux-0.0~0d52f7d8-0.el7_8.noarch.rpm` | Testing ||
+| v0.2.testing.1 | Clean | `rke2-selinux-0.2-1.el7_8.noarch.rpm` | Testing ||
+| v0.2.latest.1 | Clean | `rke2-selinux-0.2-1.el7_8.noarch.rpm` | Latest ||
+| v0.2.latest.2 | Clean | `rke2-selinux-0.2-2.el7_8.noarch.rpm` | Latest ||

--- a/rke2-selinux.spec
+++ b/rke2-selinux.spec
@@ -22,7 +22,7 @@ restorecon -R /var/run/flannel
 
 Name:   rke2-selinux
 Version:	%{rke2_selinux_version}
-Release:	%{rke2_selinux_release}%{?dist}
+Release:	%{rke2_selinux_release}.el7_8
 Summary:	SELinux policy module for rke2
 
 Group:	System Environment/Base		

--- a/scripts/upload-repo
+++ b/scripts/upload-repo
@@ -10,8 +10,11 @@ if [ -z "$RPM_CHANNEL" ]; then
   exit 1
 fi
 
-TARGET_S3_PATH="rke2/$RPM_CHANNEL/common/centos/7/noarch"
-TARGET_SOURCE_S3_PATH="rke2/$RPM_CHANNEL/common/centos/7/source"
+TARGET_EL7_S3_PATH="rke2/$RPM_CHANNEL/common/centos/7/noarch"
+TARGET_EL7_SOURCE_S3_PATH="rke2/$RPM_CHANNEL/common/centos/7/source"
+
+TARGET_EL8_S3_PATH="rke2/$RPM_CHANNEL/common/centos/8/noarch"
+TARGET_EL8_SOURCE_S3_PATH="rke2/$RPM_CHANNEL/common/centos/8/source"
 
 case "$RPM_CHANNEL" in
   "testing")
@@ -51,5 +54,9 @@ case "$RPM_CHANNEL" in
     ;;
 esac
 
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_S3_PATH dist/rpm/**/rke2-*.rpm
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_SOURCE_S3_PATH dist/source/rke2-*src.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL7_S3_PATH dist/rpm/**/rke2-*.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL7_SOURCE_S3_PATH dist/source/rke2-*src.rpm
+
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL8_S3_PATH dist/rpm/**/rke2-*.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL8_SOURCE_S3_PATH dist/source/rke2-*src.rpm
+


### PR DESCRIPTION
This will make `rke2-selinux` marked for both el7 and el8, as well as push to both of the corresponding RPM repositories.

https://github.com/rancher/rke2/issues/16

Signed-off-by: Chris Kim <oats87g@gmail.com>