### PR TITLE
fix etcd failure to start on centos 8

### DIFF
--- a/rke2.te
+++ b/rke2.te
@@ -18,3 +18,4 @@ container_read_lib_files(rke2_service_t)
 rke2_service_domain_template(rke2_service_db)
 container_manage_lib_dirs(rke2_service_db_t)
 container_manage_lib_files(rke2_service_db_t)
+allow rke2_service_db_t container_var_lib_t:file { map };


### PR DESCRIPTION
addresses errors suchs as: `sudo ausearch -ts recent -c etcd`
```
----
time->Fri Sep  4 23:20:53 2020
type=PROCTITLE msg=audit(1599261653.116:978): proctitle=65746364002D2D636F6E6669672D66696C653D2F7661722F6C69622F72616E636865722F726B65322F7365727665722F64622F657463642F636F6E666967
type=SYSCALL msg=audit(1599261653.116:978): arch=c000003e syscall=9 success=no exit=-13 a0=0 a1=280000000 a2=1 a3=8001 items=0 ppid=28621 pid=28674 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="etcd" exe="/usr/local/bin/etcd" subj=system_u:system_r:rke2_service_db_t:s0:c240,c412 key=(null)
type=AVC msg=audit(1599261653.116:978): avc:  denied  { map } for pid=28674 comm="etcd" path="/var/lib/rancher/rke2/server/db/etcd/member/snap/db" dev="vda1" ino=9135551 scontext=system_u:system_r:rke2_service_db_t:s0:c240,c412 tcontext=system_u:object_r:container_var_lib_t:s0 tclass=file permissive=0
```
