### PR TITLE
Set the keep flag to 100000 so that we keep the last 100,000 RPMs

### DIFF
--- a/scripts/upload-repo
+++ b/scripts/upload-repo
@@ -54,9 +54,9 @@ case "$RPM_CHANNEL" in
     ;;
 esac
 
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL7_S3_PATH dist/rpm/**/rke2-*.rpm
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL7_SOURCE_S3_PATH dist/source/rke2-*src.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL7_S3_PATH --keep 100000 dist/rpm/**/rke2-*.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL7_SOURCE_S3_PATH --keep 100000 dist/source/rke2-*src.rpm
 
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL8_S3_PATH dist/rpm/**/rke2-*.rpm
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL8_SOURCE_S3_PATH dist/source/rke2-*src.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL8_S3_PATH --keep 100000 dist/rpm/**/rke2-*.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL8_SOURCE_S3_PATH --keep 100000 dist/source/rke2-*src.rpm
 


### PR DESCRIPTION
This is a "short-term" fix. Long term we likely will want to maintain our own fork of rpm-s3 that does not implement such hard-logic in it for a keep (that can't even be disabled)

https://github.com/rancher/rke2/issues/386

Signed-off-by: Chris Kim <oats87g@gmail.com>