### PR TITLE
support for rke2 data-dir under /opt

### DIFF
--- a/policy/centos7/rke2.fc
+++ b/policy/centos7/rke2.fc
@@ -1,6 +1,12 @@
 # vim: sw=8:ts=8:et
 /etc/systemd/system/rke2.*                                          --  gen_context(system_u:object_r:container_unit_file_t,s0)
 /lib/systemd/system/rke2.*                                          --  gen_context(system_u:object_r:container_unit_file_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots              -d  gen_context(system_u:object_r:container_share_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*        -d  gen_context(system_u:object_r:container_share_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*/.*         <<none>>
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/sandboxes(/.*)?            gen_context(system_u:object_r:container_share_t,s0)
 /usr/local/lib/systemd/system/rke2.*                                --  gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/bin/rke2                                                       --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/rke2                                                 --  gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/centos8/rke2.fc
+++ b/policy/centos8/rke2.fc
@@ -1,6 +1,12 @@
 # vim: sw=8:ts=8:et
 /etc/systemd/system/rke2.*                                          --  gen_context(system_u:object_r:container_unit_file_t,s0)
 /lib/systemd/system/rke2.*                                          --  gen_context(system_u:object_r:container_unit_file_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots              -d  gen_context(system_u:object_r:container_share_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*        -d  gen_context(system_u:object_r:container_share_t,s0)
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*/.*         <<none>>
+/opt/(.*/)?var/lib/rancher/rke2/agent/containerd/[^/]*/sandboxes(/.*)?            gen_context(system_u:object_r:container_share_t,s0)
 /usr/local/lib/systemd/system/rke2.*                                --  gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/bin/rke2                                                       --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/rke2                                                 --  gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
Add file-context definitions that should allow for an user to specify an
rke2 data-dir under /opt e.g. /opt/var/lib/rancher/rke2

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
