### PR TITLE
fix the centos-8 build

### DIFF
--- a/policy/centos8/rke2-selinux.spec
+++ b/policy/centos8/rke2-selinux.spec
@@ -18,14 +18,14 @@ restorecon -R /var/run/flannel
 
 
 %define selinux_policyver 3.13.1-252
-%define container_policyver 2.124.0-1
+%define container_policyver 2.144.0-1
 
 Name:   rke2-selinux
 Version:	%{rke2_selinux_version}
 Release:	%{rke2_selinux_release}.el8
 Summary:	SELinux policy module for rke2
 
-Group:	System Environment/Base		
+Group:	System Environment/Base
 License:	ASL 2.0
 URL:		http://rancher.com
 Source0:	rke2.pp

--- a/policy/centos8/rke2.if
+++ b/policy/centos8/rke2.if
@@ -9,15 +9,14 @@ interface(`rke2_filetrans_named_content',`
         type container_share_t;
         type container_var_lib_t;
         type container_var_run_t;
+        type container_kvm_var_run_t;
         type var_lib_t;
     ')
 
     container_filetrans_named_content($1)
     files_pid_filetrans($1, container_var_run_t, dir, "rke2")
     filetrans_pattern($1, container_var_lib_t, container_runtime_exec_t, dir, "data")
-    filetrans_pattern($1, container_var_lib_t, container_share_t, dir, "snapshots")
     filetrans_pattern($1, container_var_lib_t, container_file_t, dir, "pods")
-    filetrans_pattern($1, container_var_run_t, container_runtime_tmpfs_t, dir, "shm")
     filetrans_pattern($1, var_lib_t, container_var_lib_t, dir, "kubelet")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")


### PR DESCRIPTION
- minimally depend on container-selinux 2.144
- remove sandboxes and shm transitions that are now included in the upstream macro
- require container_kvm_var_run_t in the rke2_filetrans_named_content macro so as to sidestep a bug in upstream

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
