### PR TITLE
Add policy to enable reading container logs

### DIFF
--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -19,3 +19,22 @@ rke2_service_domain_template(rke2_service_db)
 container_manage_lib_dirs(rke2_service_db_t)
 container_manage_lib_files(rke2_service_db_t)
 allow rke2_service_db_t container_var_lib_t:file { map };
+
+########################
+# type rke_logreader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type container_log_t;
+        class dir { read search };
+        class file { open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_logreader)
+virt_sandbox_domain(rke_logreader_t)
+corenet_unconfined(rke_logreader_t)
+allow rke_logreader_t container_log_t:dir { open read search };
+allow rke_logreader_t container_log_t:lnk_file { getattr read };
+allow rke_logreader_t container_log_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:dir search;
+allow rke_logreader_t container_var_lib_t:file { getattr open read };

--- a/policy/centos8/rke2.te
+++ b/policy/centos8/rke2.te
@@ -19,3 +19,22 @@ rke2_service_domain_template(rke2_service_db)
 container_manage_lib_dirs(rke2_service_db_t)
 container_manage_lib_files(rke2_service_db_t)
 allow rke2_service_db_t container_var_lib_t:file { map };
+
+########################
+# type rke_logreader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type container_log_t;
+        class dir { read search };
+        class file { open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_logreader)
+virt_sandbox_domain(rke_logreader_t)
+corenet_unconfined(rke_logreader_t)
+allow rke_logreader_t container_log_t:dir { open read search };
+allow rke_logreader_t container_log_t:lnk_file { getattr read };
+allow rke_logreader_t container_log_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:dir search;
+allow rke_logreader_t container_var_lib_t:file { getattr open read };


### PR DESCRIPTION
Without this patch, in both RKE1 and RKE2, containers that need to read
/var/log/containers (such as the fluentbit containers from the logging
operator) are denied by SELinux. In the case of RKE1, regular containers
running with type container_t are blocked from reading container logs in
/var/log/containers whose file context type are container_log_t, as well
as from following those symlinks to the true path of the logs in
/var/lib/docker/containers which docker creates with file context type
container_var_lib_t. In the case of RKE1, regular containers are blocked
from reading container log files and from following symlinks to
/var/log/pods.

The container-selinux package allows containers to transition to domain
container_logreader_t, which solves part of the problem but does not
allow containers to follow symlinks or read internal docker state files.

This patch adds new policy rules to create a new container_domain type
rke_logreader_t which containers can transition to. This domain allows
containers to read container log files and to follow symlinks to their
true locations. It also allows them to read files with label
container_var_lib_t, though this is only required for RKE1 and not RKE2.

This RPM will now need to be newly installed on RKE1, so a rename may be
necessary.

https://github.com/rancher/rancher/issues/30949