### PR TITLE
Allow rke_logreader_t to read rancher logs

### DIFF
--- a/policy/centos7/rke2.fc
+++ b/policy/centos7/rke2.fc
@@ -5,6 +5,7 @@
 /usr/bin/rke2                                                       --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/rke2                                                 --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/rancher/rke(/.*)?                                              gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots              -d  gen_context(system_u:object_r:container_share_t,s0)

--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -38,3 +38,4 @@ allow rke_logreader_t container_log_t:lnk_file { getattr read };
 allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };

--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -26,6 +26,7 @@ allow rke2_service_db_t container_var_lib_t:file { map };
 gen_require(`
         type container_runtime_t, unconfined_service_t;
         type container_log_t;
+        type syslogd_var_run_t;
         class dir { read search };
         class file { open read };
         class lnk_file { getattr read };
@@ -39,3 +40,5 @@ allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
+allow rke_logreader_t syslogd_var_run_t:dir read;
+allow rke_logreader_t syslogd_var_run_t:file { getattr open read };

--- a/policy/centos8/rke2.fc
+++ b/policy/centos8/rke2.fc
@@ -5,6 +5,7 @@
 /usr/bin/rke2                                                       --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/rke2                                                 --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/rancher/rke(/.*)?                                              gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots              -d  gen_context(system_u:object_r:container_share_t,s0)

--- a/policy/centos8/rke2.te
+++ b/policy/centos8/rke2.te
@@ -38,3 +38,4 @@ allow rke_logreader_t container_log_t:lnk_file { getattr read };
 allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };

--- a/policy/centos8/rke2.te
+++ b/policy/centos8/rke2.te
@@ -26,6 +26,7 @@ allow rke2_service_db_t container_var_lib_t:file { map };
 gen_require(`
         type container_runtime_t, unconfined_service_t;
         type container_log_t;
+        type syslogd_var_run_t;
         class dir { read search };
         class file { open read };
         class lnk_file { getattr read };
@@ -39,3 +40,5 @@ allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
+allow rke_logreader_t syslogd_var_run_t:dir read;
+allow rke_logreader_t syslogd_var_run_t:file { getattr open read };


### PR DESCRIPTION
Without this patch, logging aggregator pods for RKE1 cannot read
symlinks under /var/lib/rancher/rke even though their rke_logreader_t
label allows them to read container logs and docker logs. Add a policy
and fcontext equivalent to the existing RKE2 log policy to allow
containers with the rke_logreader_t label to read linked logs under
/var/lib/rancher/rke/.

https://github.com/rancher/rancher/issues/30949
Needed by https://github.com/rancher/charts/pull/1049