### PR TITLE
fix for rke2 service types unable to read certs

### DIFF
--- a/policy/centos7/rke2.if
+++ b/policy/centos7/rke2.if
@@ -47,4 +47,6 @@ template(`rke2_service_domain_template',`
     corenet_udp_bind_all_ports($1_t)
     corenet_tcp_bind_all_ports($1_t)
     corenet_tcp_connect_all_ports($1_t)
+
+    miscfiles_read_all_certs($1_t)
 ')

--- a/policy/centos8/rke2.if
+++ b/policy/centos8/rke2.if
@@ -46,4 +46,6 @@ template(`rke2_service_domain_template',`
     corenet_udp_bind_all_ports($1_t)
     corenet_tcp_bind_all_ports($1_t)
     corenet_tcp_connect_all_ports($1_t)
+
+    miscfiles_read_all_certs($1_t)
 ')


### PR DESCRIPTION
Haven't tested this yet but it should do the trick.

Addresses rancher/rke2#965