### PR TITLE
Add rules for Cilium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .dapper
 /dist
+/.vagrant/

--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -1,7 +1,8 @@
 policy_module(rke2, 1.0.0)
 
 gen_require(`
-    type container_runtime_t, unconfined_service_t;
+    type container_runtime_t, iptables_t, spc_t, unconfined_service_t;
+    class bpf { map_create map_read map_write prog_load prog_run };
 ')
 rke2_filetrans_named_content(container_runtime_t)
 rke2_filetrans_named_content(unconfined_service_t)
@@ -19,3 +20,9 @@ rke2_service_domain_template(rke2_service_db)
 container_manage_lib_dirs(rke2_service_db_t)
 container_manage_lib_files(rke2_service_db_t)
 allow rke2_service_db_t container_var_lib_t:file { map };
+
+##########
+# Cilium #
+##########
+fs_list_cgroup_dirs(iptables_t)
+allow spc_t self:bpf { map_create map_read map_write prog_load prog_run };


### PR DESCRIPTION
This PR contains the change in rke2 policy necessary to run Cilium on Centos 7. It also contains a preparatory change which fixes the Vagrantfile and adds a bit of customization to it (installation of rke2, adjustment of resources and optional mainline kernel usage). More details in commit messages.

To sum it up, this change can be tested by the following steps.

Building the policies **on the host**:

```bash
make
```

Preparing and entering the Vagrant environment:

```bash
vagrant up
vagrant provision --provision-with=kernel-mainline
vagrant ssh
```

Editing the rke2 configuration (`/etc/rancher/rke2/config.yaml`) and adding there:

```
cni: cilium
```

Running rke2:

```
systemctl enable --now rke2-server
```

Checking if Cilium is able to run:

```
# systemctl enable --now rke2-server
Created symlink from /etc/systemd/system/multi-user.target.wants/rke2-server.service to /usr/lib/systemd/system/rke2-server.service.
# export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
# ./kubectl get pods -A | grep cilium
kube-system   cilium-fd6w7                                     1/1     Running     0          12m
kube-system   cilium-node-init-mtcmk                           1/1     Running     0          12m
kube-system   cilium-operator-596fdcf67-c4r48                  1/1     Running     0          12m
kube-system   cilium-operator-596fdcf67-mlt7p                  0/1     Pending     0          12m
kube-system   helm-install-rke2-cilium-mjktd
```

Ref: rancher/rke2#1273