### PR TITLE
adapt boto3 pin adopted by rancher/rke2-packaging

### DIFF
--- a/policy/centos7/scripts/upload-repo
+++ b/policy/centos7/scripts/upload-repo
@@ -7,6 +7,7 @@ popd
 
 yum install -y epel-release
 yum install -y git python2-pip python-deltarpm
+pip install boto3==1.17.112
 pip install --cache-dir=/var/cache/pip/ \
   git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
 

--- a/policy/centos8/scripts/upload-repo
+++ b/policy/centos8/scripts/upload-repo
@@ -7,6 +7,7 @@ popd
 
 yum install -y epel-release
 yum install -y git python2-pip python-deltarpm
+pip install boto3==1.17.112
 pip install --cache-dir=/var/cache/pip/ \
   git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
 


### PR DESCRIPTION
Because boto3 is being ornery.

See https://github.com/rancher/rke2-packaging/pull/18

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
