### PR TITLE
SLE Micro /opt/rke2/bin/rke2 support and fixing watch for TLS certs

### DIFF
--- a/Dockerfile.slemicro.dapper
+++ b/Dockerfile.slemicro.dapper
@@ -1,9 +1,8 @@
-FROM centos:8
+FROM registry.suse.com/bci/bci-base:15.4
 
-RUN find /etc/yum.repos.d -type f -name '*.repo' -exec \
-    sed -i -e '/mirrorlist.*/d' -e 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' {} \;
-RUN yum install -y epel-release \
- && yum -y install container-selinux git rpm-build selinux-policy-devel yum-utils
+RUN zypper addrepo https://download.opensuse.org/repositories/security:/SELinux/15.4/security:SELinux.repo
+RUN zypper --gpg-auto-import-keys refresh
+RUN zypper in -y -n --force-resolution container-selinux git rpm-build selinux-policy-devel
 
 ENV DAPPER_SOURCE /source
 ENV DAPPER_OUTPUT ./dist

--- a/policy/slemicro/rke2.fc
+++ b/policy/slemicro/rke2.fc
@@ -9,6 +9,7 @@
 /usr/local/lib/systemd/system/rke2.*                                --  gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/bin/rke2                                                       --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/rke2                                                 --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/opt/rke2/bin/rke2                                                  --  gen_context(system_u:object_r:container_runtime_exec_t,s0)
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)

--- a/policy/slemicro/rke2.te
+++ b/policy/slemicro/rke2.te
@@ -12,6 +12,7 @@ rke2_filetrans_named_content(unconfined_service_t)
 #######################
 rke2_service_domain_template(rke2_service)
 container_read_lib_files(rke2_service_t)
+allow rke2_service_t container_var_lib_t:file { watch };
 
 ##########################
 # type rke2_service_db_t #


### PR DESCRIPTION
Adding support for /opt/rke2/bin/rke2, where the rke2 binary will reside on a transactional-update system and fixing rke2_service_t watch on container_var_lib_t. Fixes #47 in the process.