### PR TITLE
rke2_tls_t type for cert files

### DIFF
--- a/policy/centos7/rke2.fc
+++ b/policy/centos7/rke2.fc
@@ -21,3 +21,4 @@
 /var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
 /var/log/containers(/.*)?                                               gen_context(system_u:object_r:container_log_t,s0)
 /var/log/pods(/.*)?                                                     gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)

--- a/policy/centos7/rke2.if
+++ b/policy/centos7/rke2.if
@@ -12,6 +12,7 @@ interface(`rke2_filetrans_named_content',`
         type container_var_run_t;
         type var_lib_t;
         type var_log_t;
+        type rke2_tls_t;
     ')
 
     #container_filetrans_named_content($1)
@@ -25,6 +26,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 
 template(`rke2_service_domain_template',`
@@ -54,4 +56,5 @@ template(`rke2_service_domain_template',`
     miscfiles_read_all_certs($1_t)
 
     admin_pattern($1_t, container_log_t)
+    admin_pattern($1_t, rke2_tls_t)
 ')

--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -38,4 +38,4 @@ allow iscsid_t self:capability dac_override;
 # type rke2_tls_t #
 ###################
 type rke2_tls_t;
-container_file(rke2_tls_t);
+files_type(rke2_tls_t);

--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -33,3 +33,9 @@ allow spc_t self:bpf { map_create map_read map_write prog_load prog_run };
 #########################
 # https://github.com/longhorn/longhorn/issues/5627#issuecomment-1577498183
 allow iscsid_t self:capability dac_override;
+
+###################
+# type rke2_tls_t #
+###################
+type rke2_tls_t;
+container_file(rke2_tls_t);

--- a/policy/centos8/rke2.fc
+++ b/policy/centos8/rke2.fc
@@ -20,6 +20,7 @@
 /var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*/.*         <<none>>
 /var/lib/rancher/rke2/agent/containerd/[^/]*/sandboxes(/.*)?            gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/rke2/server/logs(/.*)?                                 gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)
 #/var/run/flannel(/.*)?                                                  gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)

--- a/policy/centos8/rke2.if
+++ b/policy/centos8/rke2.if
@@ -13,7 +13,9 @@ interface(`rke2_filetrans_named_content',`
         type container_kvm_var_run_t;
         type var_lib_t;
         type var_log_t;
+        type rke2_tls_t;
     ')
+
     #container_filetrans_named_content($1)
     files_pid_filetrans($1, container_var_run_t, dir, "rke2")
     filetrans_pattern($1, container_var_lib_t, container_runtime_exec_t, dir, "data")
@@ -23,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 
 template(`rke2_service_domain_template',`
@@ -52,4 +55,5 @@ template(`rke2_service_domain_template',`
     miscfiles_read_all_certs($1_t)
 
     admin_pattern($1_t, container_log_t)
+    admin_pattern($1_t, rke2_tls_t)
 ')

--- a/policy/centos8/rke2.te
+++ b/policy/centos8/rke2.te
@@ -26,3 +26,9 @@ allow rke2_service_db_t container_var_lib_t:file { map };
 #########################
 # https://github.com/longhorn/longhorn/issues/5627#issuecomment-1577498183
 allow iscsid_t self:capability dac_override;
+
+###################
+# type rke2_tls_t #
+###################
+type rke2_tls_t;
+container_file(rke2_tls_t);

--- a/policy/centos9/rke2.fc
+++ b/policy/centos9/rke2.fc
@@ -20,6 +20,7 @@
 /var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*/.*         <<none>>
 /var/lib/rancher/rke2/agent/containerd/[^/]*/sandboxes(/.*)?            gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/rke2/server/logs(/.*)?                                 gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)
 #/var/run/flannel(/.*)?                                                  gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)

--- a/policy/centos9/rke2.if
+++ b/policy/centos9/rke2.if
@@ -13,6 +13,7 @@ interface(`rke2_filetrans_named_content',`
         type container_kvm_var_run_t;
         type var_lib_t;
         type var_log_t;
+        type rke2_tls_t;
     ')
 
     #container_filetrans_named_content($1)
@@ -24,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 
 template(`rke2_service_domain_template',`
@@ -53,4 +55,5 @@ template(`rke2_service_domain_template',`
     miscfiles_read_all_certs($1_t)
 
     admin_pattern($1_t, container_log_t)
+    admin_pattern($1_t, rke2_tls_t)
 ')

--- a/policy/centos9/rke2.te
+++ b/policy/centos9/rke2.te
@@ -27,3 +27,9 @@ allow rke2_service_db_t container_var_lib_t:file { map };
 #########################
 # https://github.com/longhorn/longhorn/issues/5627#issuecomment-1577498183
 allow iscsid_t self:capability dac_override;
+
+###################
+# type rke2_tls_t #
+###################
+type rke2_tls_t;
+container_file(rke2_tls_t);

--- a/policy/microos/rke2.fc
+++ b/policy/microos/rke2.fc
@@ -20,6 +20,7 @@
 /var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*/.*         <<none>>
 /var/lib/rancher/rke2/agent/containerd/[^/]*/sandboxes(/.*)?            gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/rke2/server/logs(/.*)?                                 gen_context(system_u:object_r:container_log_t,s0)
++/var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)
 #/var/run/flannel(/.*)?                                                  gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)

--- a/policy/microos/rke2.if
+++ b/policy/microos/rke2.if
@@ -13,6 +13,7 @@ interface(`rke2_filetrans_named_content',`
         type container_kvm_var_run_t;
         type var_lib_t;
         type var_log_t;
+        type rke2_tls_t;
     ')
 
     #container_filetrans_named_content($1)
@@ -24,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 
 template(`rke2_service_domain_template',`
@@ -53,4 +55,5 @@ template(`rke2_service_domain_template',`
     miscfiles_read_all_certs($1_t)
 
     admin_pattern($1_t, container_log_t)
+    admin_pattern($1_t, rke2_tls_t)
 ')

--- a/policy/microos/rke2.te
+++ b/policy/microos/rke2.te
@@ -26,3 +26,9 @@ allow rke2_service_db_t container_var_lib_t:file { map };
 #########################
 # https://github.com/longhorn/longhorn/issues/5627#issuecomment-1577498183
 allow iscsid_t self:capability dac_override;
+
+###################
+# type rke2_tls_t #
+###################
+type rke2_tls_t;
+container_file(rke2_tls_t);

--- a/policy/slemicro/rke2.fc
+++ b/policy/slemicro/rke2.fc
@@ -21,6 +21,7 @@
 /var/lib/rancher/rke2/agent/containerd/[^/]*/snapshots/[^/]*/.*         <<none>>
 /var/lib/rancher/rke2/agent/containerd/[^/]*/sandboxes(/.*)?            gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/rke2/server/logs(/.*)?                                 gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)
 #/var/run/flannel(/.*)?                                                  gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
 #/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)

--- a/policy/slemicro/rke2.if
+++ b/policy/slemicro/rke2.if
@@ -13,6 +13,7 @@ interface(`rke2_filetrans_named_content',`
         type container_kvm_var_run_t;
         type var_lib_t;
         type var_log_t;
+        type rke2_tls_t; 
     ')
 
     #container_filetrans_named_content($1)
@@ -24,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 
 template(`rke2_service_domain_template',`
@@ -53,4 +55,5 @@ template(`rke2_service_domain_template',`
     miscfiles_read_all_certs($1_t)
 
     admin_pattern($1_t, container_log_t)
+    admin_pattern($1_t, rke2_tls_t)
 ')

--- a/policy/slemicro/rke2.te
+++ b/policy/slemicro/rke2.te
@@ -27,3 +27,9 @@ allow rke2_service_db_t container_var_lib_t:file { map };
 #########################
 # https://github.com/longhorn/longhorn/issues/5627#issuecomment-1577498183
 allow iscsid_t self:capability dac_override;
+
+###################
+# type rke2_tls_t #
+###################
+type rke2_tls_t;
+container_file(rke2_tls_t);


### PR DESCRIPTION
This PR will add the following:

- A new data type `rke2_tls_t` for the **server's** certificates and keys under `/var/lib/rancher/rke2/server/tls`
- A transition rule and labeling for any file under the mentioned directory.
- A admin privileges for rke2_service_t and rke2_service_db_t to the new type `rke2_tls_t`

- https://github.com/rancher/rke2-selinux/issues/31
- https://github.com/rancher/rancher/issues/42415