### PR TITLE
Add selinux write and connectto to kine sock

### DIFF
--- a/policy/centos7/rke2.te
+++ b/policy/centos7/rke2.te
@@ -13,6 +13,8 @@ rke2_filetrans_named_content(unconfined_service_t)
 #######################
 rke2_service_domain_template(rke2_service)
 container_read_lib_files(rke2_service_t)
+allow rke2_service_t container_var_lib_t:sock_file { write };
+allow rke2_service_t container_runtime_t:unix_stream_socket { connectto };
 
 ##########################
 # type rke2_service_db_t #

--- a/policy/centos8/rke2.te
+++ b/policy/centos8/rke2.te
@@ -12,6 +12,8 @@ rke2_filetrans_named_content(unconfined_service_t)
 #######################
 rke2_service_domain_template(rke2_service)
 container_read_lib_files(rke2_service_t)
+allow rke2_service_t container_var_lib_t:sock_file { write };
+allow rke2_service_t container_runtime_t:unix_stream_socket { connectto };
 
 ##########################
 # type rke2_service_db_t #

--- a/policy/centos9/rke2.te
+++ b/policy/centos9/rke2.te
@@ -13,6 +13,8 @@ rke2_filetrans_named_content(unconfined_service_t)
 rke2_service_domain_template(rke2_service)
 container_read_lib_files(rke2_service_t)
 allow rke2_service_t container_var_lib_t:file { watch };
+allow rke2_service_t container_var_lib_t:sock_file { write };
+allow rke2_service_t container_runtime_t:unix_stream_socket { connectto };
 
 ##########################
 # type rke2_service_db_t #

--- a/policy/microos/rke2.te
+++ b/policy/microos/rke2.te
@@ -12,6 +12,8 @@ rke2_filetrans_named_content(unconfined_service_t)
 #######################
 rke2_service_domain_template(rke2_service)
 container_read_lib_files(rke2_service_t)
+allow rke2_service_t container_var_lib_t:sock_file { write };
+allow rke2_service_t container_runtime_t:unix_stream_socket { connectto };
 
 ##########################
 # type rke2_service_db_t #

--- a/policy/slemicro/rke2.te
+++ b/policy/slemicro/rke2.te
@@ -13,6 +13,8 @@ rke2_filetrans_named_content(unconfined_service_t)
 rke2_service_domain_template(rke2_service)
 container_read_lib_files(rke2_service_t)
 allow rke2_service_t container_var_lib_t:file { watch };
+allow rke2_service_t container_var_lib_t:sock_file { write };
+allow rke2_service_t container_runtime_t:unix_stream_socket { connectto };
 
 ##########################
 # type rke2_service_db_t #


### PR DESCRIPTION
- This PR will add the fix for the policy that makes Kine unusable in SELinux environment

- Issue related to this PR
https://github.com/rancher/rke2/issues/5924

Obs:
- This policy was tested on RHEL 9 with Rke2 running with SQLite