### PR TITLE
Transfer containerd.log from container_var_lib_t to container_log_t

### DIFF
--- a/policy/centos7/rke2.if
+++ b/policy/centos7/rke2.if
@@ -26,6 +26,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, container_log_t, file, "containerd.log")
     filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 

--- a/policy/centos8/rke2.if
+++ b/policy/centos8/rke2.if
@@ -25,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, container_log_t, file, "containerd.log")
     filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 

--- a/policy/centos9/rke2.if
+++ b/policy/centos9/rke2.if
@@ -25,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, container_log_t, file, "containerd.log")
     filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 

--- a/policy/microos/rke2.if
+++ b/policy/microos/rke2.if
@@ -25,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, container_log_t, file, "containerd.log")
     filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 

--- a/policy/slemicro/rke2.if
+++ b/policy/slemicro/rke2.if
@@ -25,6 +25,7 @@ interface(`rke2_filetrans_named_content',`
     filetrans_pattern($1, var_log_t, container_log_t, dir, "pods")
     filetrans_pattern($1, var_log_t, container_log_t, dir, "containers")
     filetrans_pattern($1, container_var_lib_t, container_log_t, dir, "logs")
+    filetrans_pattern($1, container_var_lib_t, container_log_t, file, "containerd.log")
     filetrans_pattern($1, container_var_lib_t, rke2_tls_t, dir, "tls")
 ')
 


### PR DESCRIPTION
It was discovered that the `containerd.log` file was not in the `container_log_t` policy and it was in the `container_var_lib_t` policy because the file was created after the policies being applied and it's specific for the container directory `/var/lib/rancher/rke2/agent/containerd` and it does not use a `logs` directory as `kubelet` does.

this PR aims to transfer the policy from `container_var_lib_t` to `container_log_t`

### Verification

- Install rke2 with rpms with the version the new version

- run rke2 server

- get the file infos for `containerd.log` and see it's with `container_log_ t` instead of `container_var_lib_t`

```bash
ls -lZ /var/lib/rancher/rke2/agent/containerd/containerd.log
```

the result from the command above need to be something like this
```bash
-rw-r--r--. 1 root root system_u:object_r:container_log_t:s0 3888562 Jul 15 05:48 /var/lib/rancher/rke2/agent/containerd/containerd.log
```

### Observations

We should probably change the `containerd.log` default path to a `/logs` inside `/var/lib/rancher/rke2/agent/containerd` in future interations.