### PR TITLE
Fix restorecon flags to ensure full SELinux relabel

### DIFF
--- a/policy/centos7/rke2-selinux.spec
+++ b/policy/centos7/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server; \
-restorecon -R -i /etc/systemd/system/rke2*; \
-restorecon -R -i /usr/lib/systemd/system/rke2*; \
-restorecon -R /var/lib/cni; \
-restorecon -R /opt/cni; \
-restorecon -R /etc/cni; \
-restorecon -R /var/lib/kubelet; \
-restorecon -R /var/lib/rancher; \
-restorecon -R /var/run/k3s; \
-restorecon -R /var/run/flannel
+restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
+restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -FRT 0 /var/lib/cni; \
+restorecon -FRT 0 /opt/cni; \
+restorecon -FRT 0 /etc/cni; \
+restorecon -FRT 0 /var/lib/kubelet; \
+restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/run/k3s; \
+restorecon -FRT 0 /var/run/flannel
 
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.107-3

--- a/policy/centos8/rke2-selinux.spec
+++ b/policy/centos8/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server; \
-restorecon -R -i /etc/systemd/system/rke2*; \
-restorecon -R -i /usr/lib/systemd/system/rke2*; \
-restorecon -R /var/lib/cni; \
-restorecon -R /opt/cni; \
-restorecon -R /etc/cni; \
-restorecon -R /var/lib/kubelet; \
-restorecon -R /var/lib/rancher; \
-restorecon -R /var/run/k3s; \
-restorecon -R /var/run/flannel
+restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
+restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -FRT 0 /var/lib/cni; \
+restorecon -FRT 0 /opt/cni; \
+restorecon -FRT 0 /etc/cni; \
+restorecon -FRT 0 /var/lib/kubelet; \
+restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/run/k3s; \
+restorecon -FRT 0 /var/run/flannel
 
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.167.0-1

--- a/policy/centos9/rke2-selinux.spec
+++ b/policy/centos9/rke2-selinux.spec
@@ -16,16 +16,16 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server; \
-restorecon -R -i /etc/systemd/system/rke2*; \
-restorecon -R -i /usr/local/lib/systemd/system/rke2*; \
-restorecon -R -i /usr/lib/systemd/system/rke2*; \
-restorecon -R /var/lib/cni; \
-restorecon -R /opt/cni; \
-restorecon -R /etc/cni; \
-restorecon -R /var/lib/kubelet; \
-restorecon -R /var/lib/rancher; \
-restorecon -R /var/run/k3s; \
-restorecon -R /var/run/flannel
+restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
+restorecon -FRT 0 -i /usr/local/lib/systemd/system/rke2*; \
+restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -FRT 0 /var/lib/cni; \
+restorecon -FRT 0 /opt/cni; \
+restorecon -FRT 0 /etc/cni; \
+restorecon -FRT 0 /var/lib/kubelet; \
+restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/run/k3s; \
+restorecon -FRT 0 /var/run/flannel
 
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.191.0-1

--- a/policy/microos/rke2-selinux.spec
+++ b/policy/microos/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server; \
-restorecon -R -i /etc/systemd/system/rke2*; \
-restorecon -R -i /usr/lib/systemd/system/rke2*; \
-restorecon -R /var/lib/cni; \
-restorecon -R /opt/cni; \
-restorecon -R /etc/cni; \
-restorecon -R /var/lib/kubelet; \
-restorecon -R /var/lib/rancher; \
-restorecon -R /var/run/k3s; \
-restorecon -R /var/run/flannel
+restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
+restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -FRT 0 /var/lib/cni; \
+restorecon -FRT 0 /opt/cni; \
+restorecon -FRT 0 /etc/cni; \
+restorecon -FRT 0 /var/lib/kubelet; \
+restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/run/k3s; \
+restorecon -FRT 0 /var/run/flannel
 
 %define selinux_policyver 20210716-3.1
 %define container_policyver 2.164.2-1.1

--- a/policy/slemicro/rke2-selinux.spec
+++ b/policy/slemicro/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server; \
-restorecon -R -i /etc/systemd/system/rke2*; \
-restorecon -R -i /usr/lib/systemd/system/rke2*; \
-restorecon -R /var/lib/cni; \
-restorecon -R /opt/cni; \
-restorecon -R /etc/cni; \
-restorecon -R /var/lib/kubelet; \
-restorecon -R /var/lib/rancher; \
-restorecon -R /var/run/k3s; \
-restorecon -R /var/run/flannel
+restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
+restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -FRT 0 /var/lib/cni; \
+restorecon -FRT 0 /opt/cni; \
+restorecon -FRT 0 /etc/cni; \
+restorecon -FRT 0 /var/lib/kubelet; \
+restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/run/k3s; \
+restorecon -FRT 0 /var/run/flannel
 
 %define selinux_policyver 20210716-3.1
 %define selinux_policyver_build 3.13.1-252


### PR DESCRIPTION
Fixes: https://github.com/rancher/rancher/issues/52616
Use `restorecon -FRT 0` in RPM scriptlets to perform a complete SELinux relabel.
The` -F `flag forces full context replacement (including the SELinux user), while `-T 0 ` enables multithreaded relabeling for faster execution.
This prevents directories created under the unconfined domain during RPM install from inheriting `unconfined_u` and ensures they are correctly labeled as `system_u`.