### PR TITLE
Remove unsupported restorecon -T 0 flag for RHEL 8

### DIFF
--- a/policy/centos8/rke2-selinux.spec
+++ b/policy/centos8/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server; \
-restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
-restorecon -FRT 0 /var/lib/cni; \
-restorecon -FRT 0 /opt/cni; \
-restorecon -FRT 0 /etc/cni; \
-restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher; \
-restorecon -FRT 0 /var/run/k3s; \
-restorecon -FRT 0 /var/run/flannel
+restorecon -FR -i /etc/systemd/system/rke2*; \
+restorecon -FR -i /usr/lib/systemd/system/rke2*; \
+restorecon -FR /var/lib/cni; \
+restorecon -FR /opt/cni; \
+restorecon -FR /etc/cni; \
+restorecon -FR /var/lib/kubelet; \
+restorecon -FR /var/lib/rancher; \
+restorecon -FR /var/run/k3s; \
+restorecon -FR /var/run/flannel
 
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.167.0-1


### PR DESCRIPTION
This fixes an issue introduced when enabling multithreaded restorecon (-T 0) across all OS variants.

RHEL 8 restorecon implementation does not support the -T option, which causes:
```
restorecon: invalid option -- 'T'
```
To restore compatibility with RHEL 8, this change removes the unsupported flag and keeps only the valid options.

Additional Notes:
RHEL 7 support has already been dropped upstream, so no fix is required there.