### PR TITLE
Use restorecon only in rke2 directory and not in rancher directory

### DIFF
--- a/policy/centos10/rke2-selinux.spec
+++ b/policy/centos10/rke2-selinux.spec
@@ -23,7 +23,7 @@ restorecon -FRT 0 /var/lib/cni; \
 restorecon -FRT 0 /opt/cni; \
 restorecon -FRT 0 /etc/cni; \
 restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/lib/rancher/rke2; \
 restorecon -FRT 0 /var/run/k3s; \
 restorecon -FRT 0 /var/run/flannel
 

--- a/policy/centos8/rke2-selinux.spec
+++ b/policy/centos8/rke2-selinux.spec
@@ -22,7 +22,7 @@ restorecon -FR /var/lib/cni; \
 restorecon -FR /opt/cni; \
 restorecon -FR /etc/cni; \
 restorecon -FR /var/lib/kubelet; \
-restorecon -FR /var/lib/rancher; \
+restorecon -FR /var/lib/rancher/rke2; \
 restorecon -FR /var/run/k3s; \
 restorecon -FR /var/run/flannel
 

--- a/policy/centos9/rke2-selinux.spec
+++ b/policy/centos9/rke2-selinux.spec
@@ -23,7 +23,7 @@ restorecon -FRT 0 /var/lib/cni; \
 restorecon -FRT 0 /opt/cni; \
 restorecon -FRT 0 /etc/cni; \
 restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/lib/rancher/rke2; \
 restorecon -FRT 0 /var/run/k3s; \
 restorecon -FRT 0 /var/run/flannel
 

--- a/policy/microos/rke2-selinux.spec
+++ b/policy/microos/rke2-selinux.spec
@@ -22,7 +22,7 @@ restorecon -FRT 0 /var/lib/cni; \
 restorecon -FRT 0 /opt/cni; \
 restorecon -FRT 0 /etc/cni; \
 restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/lib/rancher/rke2; \
 restorecon -FRT 0 /var/run/k3s; \
 restorecon -FRT 0 /var/run/flannel
 

--- a/policy/slemicro/rke2-selinux.spec
+++ b/policy/slemicro/rke2-selinux.spec
@@ -22,7 +22,7 @@ restorecon -FRT 0 /var/lib/cni; \
 restorecon -FRT 0 /opt/cni; \
 restorecon -FRT 0 /etc/cni; \
 restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher; \
+restorecon -FRT 0 /var/lib/rancher/rke2; \
 restorecon -FRT 0 /var/run/k3s; \
 restorecon -FRT 0 /var/run/flannel
 


### PR DESCRIPTION
### Changes Requested
- rke2-selinux use restorecon in /var/lib/rancher which is not the best state of art since it's supposed to only affect /var/lib/rancher/rke2.

### Issue
- https://github.com/rancher/rke2-selinux/issues/103