### PR TITLE
pre-create default ETCD snapshots directory to fix selinux labeling

### DIFF
--- a/policy/centos10/rke2-selinux.spec
+++ b/policy/centos10/rke2-selinux.spec
@@ -15,7 +15,7 @@ umask 0066; \
 mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
-mkdir -p /var/lib/rancher/rke2/server; \
+mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
 restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
 restorecon -FRT 0 -i /usr/local/lib/systemd/system/rke2*; \
 restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \

--- a/policy/centos8/rke2-selinux.spec
+++ b/policy/centos8/rke2-selinux.spec
@@ -15,7 +15,7 @@ umask 0066; \
 mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
-mkdir -p /var/lib/rancher/rke2/server; \
+mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
 restorecon -FR -i /etc/systemd/system/rke2*; \
 restorecon -FR -i /usr/lib/systemd/system/rke2*; \
 restorecon -FR /var/lib/cni; \

--- a/policy/centos9/rke2-selinux.spec
+++ b/policy/centos9/rke2-selinux.spec
@@ -15,7 +15,7 @@ umask 0066; \
 mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
-mkdir -p /var/lib/rancher/rke2/server; \
+mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
 restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
 restorecon -FRT 0 -i /usr/local/lib/systemd/system/rke2*; \
 restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \

--- a/policy/microos/rke2-selinux.spec
+++ b/policy/microos/rke2-selinux.spec
@@ -15,7 +15,7 @@ umask 0066; \
 mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
-mkdir -p /var/lib/rancher/rke2/server; \
+mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
 restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
 restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
 restorecon -FRT 0 /var/lib/cni; \

--- a/policy/slemicro/rke2-selinux.spec
+++ b/policy/slemicro/rke2-selinux.spec
@@ -15,7 +15,7 @@ umask 0066; \
 mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
-mkdir -p /var/lib/rancher/rke2/server; \
+mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
 restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
 restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
 restorecon -FRT 0 /var/lib/cni; \


### PR DESCRIPTION
Fixes: https://github.com/rancher/rke2-selinux/issues/95

The RKE2 server [creates](https://github.com/k3s-io/k3s/blob/9850c5a3dadd6950546eedc4938b533bfb7457d0/pkg/etcd/snapshot.go#L72-L102) the default ETCD snapshots directory at runtime when no custom snapshot directory is configured. When created by the server process, SELinux applies a container runtime type_transition rule that labels the directory and snapshots direcotry  as `container_file_t`, which conflicts with the expected `container_var_lib_t`(inherit from parent direcotry)  label for RKE2 data under` /var/lib/rancher/rke2`...

This fix pre creates the default snapshot directory during `rke2-selinux` package installation and applies restorecon on the parent directory, allowing the directory to inherit the correct selinux context from its parent before the RKE2 server starts.

The change only affects the default snapshot directory. If a user configures a custom etcd snapshot directory, the RKE2 code explicitly bypasses the default path and does not use or modify it. The presence of the default directory is not create a problem but it exists and does not affect custom configurations or runtime behavior...