### PR TITLE
Fix(policy): remove force flag from restorecon

### DIFF
--- a/policy/centos10/rke2-selinux.spec
+++ b/policy/centos10/rke2-selinux.spec
@@ -16,16 +16,16 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
-restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/local/lib/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
-restorecon -FRT 0 /var/lib/cni; \
-restorecon -FRT 0 /opt/cni; \
-restorecon -FRT 0 /etc/cni; \
-restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher/rke2; \
-restorecon -FRT 0 /var/run/k3s; \
-restorecon -FRT 0 /var/run/flannel
+restorecon -RT 0 -i /etc/systemd/system/rke2*; \
+restorecon -RT 0 -i /usr/local/lib/systemd/system/rke2*; \
+restorecon -RT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -RT 0 /var/lib/cni; \
+restorecon -RT 0 /opt/cni; \
+restorecon -RT 0 /etc/cni; \
+restorecon -RT 0 /var/lib/kubelet; \
+restorecon -RT 0 /var/lib/rancher/rke2; \
+restorecon -RT 0 /var/run/k3s; \
+restorecon -RT 0 /var/run/flannel
 
 %define selinux_policyver 40.13.26-1
 %define container_policyver 2.235.0-2

--- a/policy/centos8/rke2-selinux.spec
+++ b/policy/centos8/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
-restorecon -FR -i /etc/systemd/system/rke2*; \
-restorecon -FR -i /usr/lib/systemd/system/rke2*; \
-restorecon -FR /var/lib/cni; \
-restorecon -FR /opt/cni; \
-restorecon -FR /etc/cni; \
-restorecon -FR /var/lib/kubelet; \
-restorecon -FR /var/lib/rancher/rke2; \
-restorecon -FR /var/run/k3s; \
-restorecon -FR /var/run/flannel
+restorecon -R -i /etc/systemd/system/rke2*; \
+restorecon -R -i /usr/lib/systemd/system/rke2*; \
+restorecon -R /var/lib/cni; \
+restorecon -R /opt/cni; \
+restorecon -R /etc/cni; \
+restorecon -R /var/lib/kubelet; \
+restorecon -R /var/lib/rancher/rke2; \
+restorecon -R /var/run/k3s; \
+restorecon -R /var/run/flannel
 
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.167.0-1

--- a/policy/centos9/rke2-selinux.spec
+++ b/policy/centos9/rke2-selinux.spec
@@ -16,16 +16,16 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
-restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/local/lib/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
-restorecon -FRT 0 /var/lib/cni; \
-restorecon -FRT 0 /opt/cni; \
-restorecon -FRT 0 /etc/cni; \
-restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher/rke2; \
-restorecon -FRT 0 /var/run/k3s; \
-restorecon -FRT 0 /var/run/flannel
+restorecon -RT 0 -i /etc/systemd/system/rke2*; \
+restorecon -RT 0 -i /usr/local/lib/systemd/system/rke2*; \
+restorecon -RT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -RT 0 /var/lib/cni; \
+restorecon -RT 0 /opt/cni; \
+restorecon -RT 0 /etc/cni; \
+restorecon -RT 0 /var/lib/kubelet; \
+restorecon -RT 0 /var/lib/rancher/rke2; \
+restorecon -RT 0 /var/run/k3s; \
+restorecon -RT 0 /var/run/flannel
 
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.191.0-1

--- a/policy/microos/rke2-selinux.spec
+++ b/policy/microos/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
-restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
-restorecon -FRT 0 /var/lib/cni; \
-restorecon -FRT 0 /opt/cni; \
-restorecon -FRT 0 /etc/cni; \
-restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher/rke2; \
-restorecon -FRT 0 /var/run/k3s; \
-restorecon -FRT 0 /var/run/flannel
+restorecon -RT 0 -i /etc/systemd/system/rke2*; \
+restorecon -RT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -RT 0 /var/lib/cni; \
+restorecon -RT 0 /opt/cni; \
+restorecon -RT 0 /etc/cni; \
+restorecon -RT 0 /var/lib/kubelet; \
+restorecon -RT 0 /var/lib/rancher/rke2; \
+restorecon -RT 0 /var/run/k3s; \
+restorecon -RT 0 /var/run/flannel
 
 %define selinux_policyver 20210716-3.1
 %define container_policyver 2.164.2-1.1

--- a/policy/slemicro/rke2-selinux.spec
+++ b/policy/slemicro/rke2-selinux.spec
@@ -16,15 +16,15 @@ mkdir -p /var/run/k3s; \
 umask 0077; \
 mkdir -p /var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; \
 mkdir -p /var/lib/rancher/rke2/server/db/snapshots; \
-restorecon -FRT 0 -i /etc/systemd/system/rke2*; \
-restorecon -FRT 0 -i /usr/lib/systemd/system/rke2*; \
-restorecon -FRT 0 /var/lib/cni; \
-restorecon -FRT 0 /opt/cni; \
-restorecon -FRT 0 /etc/cni; \
-restorecon -FRT 0 /var/lib/kubelet; \
-restorecon -FRT 0 /var/lib/rancher/rke2; \
-restorecon -FRT 0 /var/run/k3s; \
-restorecon -FRT 0 /var/run/flannel
+restorecon -RT 0 -i /etc/systemd/system/rke2*; \
+restorecon -RT 0 -i /usr/lib/systemd/system/rke2*; \
+restorecon -RT 0 /var/lib/cni; \
+restorecon -RT 0 /opt/cni; \
+restorecon -RT 0 /etc/cni; \
+restorecon -RT 0 /var/lib/kubelet; \
+restorecon -RT 0 /var/lib/rancher/rke2; \
+restorecon -RT 0 /var/run/k3s; \
+restorecon -RT 0 /var/run/flannel
 
 %define selinux_policyver 20210716-3.1
 %define selinux_policyver_build 3.13.1-252


### PR DESCRIPTION
Fixes: https://github.com/rancher/rke2-selinux/issues/114

Remove `-F` from `restorecon` in RPM scriptlets.

`restorecon -F` resets the full SELinux context and can override container runtime MCS labels under `/var/lib/kubelet and /var/lib/rancher`.
Dropping `-F` avoids unintended relabeling regression.