### PR TITLE
Add support for Local Path Provisioner volumes in the default path

### DIFF
--- a/policy/centos10/rke2.fc
+++ b/policy/centos10/rke2.fc
@@ -13,6 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
+/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/centos8/rke2.fc
+++ b/policy/centos8/rke2.fc
@@ -13,6 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
+/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/centos9/rke2.fc
+++ b/policy/centos9/rke2.fc
@@ -13,6 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
+/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/microos/rke2.fc
+++ b/policy/microos/rke2.fc
@@ -13,6 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
+/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/slemicro/rke2.fc
+++ b/policy/slemicro/rke2.fc
@@ -14,6 +14,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
+/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
This commit ensures that the RKE2 SELinux policy supports labelling in /opt/local-path-provisioner/<volume-id> with container_file_t type. This path is the default configuration location; K3s handles this differently.

Fixes: #62