### PR TITLE
Revert local-path-provisioner policy

### DIFF
--- a/policy/centos10/rke2.fc
+++ b/policy/centos10/rke2.fc
@@ -13,7 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
-/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
+#/opt/local-path-provisioner(/.*)?                                       gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/centos8/rke2.fc
+++ b/policy/centos8/rke2.fc
@@ -13,7 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
-/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
+#/opt/local-path-provisioner(/.*)?                                       gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/centos9/rke2.fc
+++ b/policy/centos9/rke2.fc
@@ -13,7 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
-/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
+#/opt/local-path-provisioner(/.*)?                                       gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/microos/rke2.fc
+++ b/policy/microos/rke2.fc
@@ -13,7 +13,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
-/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
+#/opt/local-path-provisioner(/.*)?                                       gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/policy/slemicro/rke2.fc
+++ b/policy/slemicro/rke2.fc
@@ -14,7 +14,7 @@
 #/var/lib/cni(/.*)?                                                      gen_context(system_u:object_r:container_var_lib_t,s0)
 /opt/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
 /etc/cni(/.*)?                                                           gen_context(system_u:object_r:container_file_t,s0)
-/opt/local-path-provisioner(/.*)?                                        gen_context(system_u:object_r:container_file_t,s0)
+#/opt/local-path-provisioner(/.*)?                                       gen_context(system_u:object_r:container_file_t,s0)
 #/var/lib/kubelet/pods(/.*)?                                             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/rke2(/.*)?                                             gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/rke2/data(/.*)?                                        gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
# Changes
- Revert the new local-path-provisioner policy since it's impacting the release process

## Note

- I will verify after the release process how we can add this policy without having problems with the already introduced policy for local-path-provisioner, specially because RHEL 10 is not having this problem but we should maintain consistency between the policys.