### PR TITLE
adding none to catch-all rule for containerd policy

### DIFF
--- a/policy/centos10/rke2.fc
+++ b/policy/centos10/rke2.fc
@@ -27,9 +27,9 @@
 /var/lib/rancher/rke2/agent/logs(/.*)?                                  gen_context(system_u:object_r:container_log_t,s0)
 /var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)
 #/var/run/flannel(/.*)?                                                 gen_context(system_u:object_r:container_var_run_t,s0)
-/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
-/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
+/run/k3s(/.*)?                                                          gen_context(system_u:object_r:container_var_run_t,s0)
+/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                     <<none>>
 /var/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
-/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
+/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 <<none>>
 #/var/log/containers(/.*)?                                              gen_context(system_u:object_r:container_log_t,s0)
 #/var/log/pods(/.*)?                                                    gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/centos9/rke2.fc
+++ b/policy/centos9/rke2.fc
@@ -27,9 +27,9 @@
 /var/lib/rancher/rke2/agent/logs(/.*)?                                  gen_context(system_u:object_r:container_log_t,s0)
 /var/lib/rancher/rke2/server/tls(/.*)?                                  gen_context(system_u:object_r:rke2_tls_t,s0)
 #/var/run/flannel(/.*)?                                                 gen_context(system_u:object_r:container_var_run_t,s0)
-/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
-/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
+/run/k3s(/.*)?                                                          gen_context(system_u:object_r:container_var_run_t,s0)
+/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                     <<none>>
 /var/run/k3s(/.*)?                                                      gen_context(system_u:object_r:container_var_run_t,s0)
-/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
+/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?                 <<none>>
 #/var/log/containers(/.*)?                                              gen_context(system_u:object_r:container_log_t,s0)
 #/var/log/pods(/.*)?                                                    gen_context(system_u:object_r:container_log_t,s0)


### PR DESCRIPTION
Issue: #108 

**Description**:
Since containerd handles it dynamically at runtime under the hood, a hardcoded rule in RKE2 only serves to cause conflicts when a system relabel occurs. This PR address the containerd rule for /shm to not be catched by the catch-all rule and then return any file when the rule is executed.

**Tests**:
Install rke2-server:
`curl -sfL https://get.rke2.io | sudo sh - && systemctl enable rke2-server --now`
Run: 
`sudo restorecon -nv -FRT 0 /var/run/k3s/containerd`


**Actual result:**
```
sudo restorecon -nv -FRT 0 /run/k3s/containerd
Would relabel /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/ccaf080cf74672e3c26cfaeb89b35c06cd70be3e39b606b353811c206778e09d/shm from system_u:object_r:container_file_t:s0:c290,c966 to system_u:object_r:container_runtime_tmpfs_t:s0
Would relabel /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/3711a5f529924060ae99d6a8a5368448d7e9e765faac431e8ff750470eb76880/shm from system_u:object_r:container_file_t:s0:c517,c1013 to system_u:object_r:container_runtime_tmpfs_t:s0
Would relabel /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/717348321a21e21b0398f0c2859eac61d0386438490975452d30220214594f0c/shm from system_u:object_r:container_file_t:s0:c372,c865 to system_u:object_r:container_runtime_tmpfs_t:s0

```

**Expected result:**
`restorecon` -nv -FRT on containerd path return nothing


**Environment:**
container-selinux-2.240.0-4.el9_7.noarch
rke2-selinux-0.23-2.el9.noarch
rke2-server: v1.35.5-rke2r2
